### PR TITLE
Replacing the Icon and path of Image

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                     <div class="item item-pink item-2 col-lg-4 col-6">
                         <div class="item-inner">
                             <div class="icon-holder">
-                                <span aria-hidden="true" class="icon icon_puzzle_alt"></span>
+                                <i class="icon fa fa-info-circle"></i>
                             </div>
                             <!--//icon-holder-->
                             <h3 class="title">About Us</h3>
@@ -141,7 +141,7 @@
                     <div class="item item-purple col-lg-4 col-6">
                         <div class="item-inner">
                             <div class="icon-holder">
-                                <img src="/assets/images/logo/git.png" class="git-icon">
+                                <img src="./assets/images/logo/git.png" class="git-icon">
                             </div>
                             <!--//icon-holder-->
                             <h3 class="title">GitHub</h3>


### PR DESCRIPTION
Updated the About us Icon and path of the Github Logo Image, as the Github Logo Image is not loading sometimes.

Sir, Please also add me as a member of the Peach PHP Organisation